### PR TITLE
Cherry pick: Create query stack size limit (upstream v0.27.0)

### DIFF
--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -116,3 +116,10 @@ func WithAPICosts(human, canonical uint64) Option {
 		costCanonical = canonical
 	})
 }
+
+// WithMaxQueryStackSize overwrites the default limit for maximum query stacks
+func WithMaxQueryStackSize(m uint32) Option {
+	return optsFn(func(k *Keeper) {
+		k.maxQueryStackSize = m
+	})
+}

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -75,6 +75,12 @@ func TestConstructorOptions(t *testing.T) {
 				assert.Equal(t, uint64(2), costCanonical)
 			},
 		},
+		"max recursion query limit": {
+			srcOpt: WithMaxQueryStackSize(1),
+			verify: func(t *testing.T, k Keeper) {
+				assert.IsType(t, uint32(1), k.maxQueryStackSize)
+			},
+		},
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {

--- a/x/wasm/keeper/recurse_test.go
+++ b/x/wasm/keeper/recurse_test.go
@@ -229,6 +229,7 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 		expectQueriesFromContract int
 		expectedGas               uint64
 		expectOutOfGas            bool
+		expectError               string
 	}{
 		"no recursion, lots of work": {
 			gasLimit: 4_000_000,
@@ -261,6 +262,17 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 			expectQueriesFromContract: 4,
 			expectOutOfGas:            true,
 		},
+		"very deep recursion, hits recursion limit": {
+			gasLimit: 10_000_000,
+			msg: Recurse{
+				Depth: 100,
+				Work:  2000,
+			},
+			expectQueriesFromContract: 10,
+			expectOutOfGas:            false,
+			expectError:               "query wasm contract failed", // Error we get from the contract instance doing the failing query, not wasmd
+			expectedGas:               10*(GasWork2k+GasReturnHashed) - 264,
+		},
 	}
 
 	contractAddr, _, ctx, keeper := initRecurseContract(t)
@@ -291,7 +303,11 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 
 			// otherwise, we expect a successful call
 			_, err := keeper.QuerySmart(ctx, contractAddr, msg)
-			require.NoError(t, err)
+			if tc.expectError != "" {
+				require.ErrorContains(t, err, tc.expectError)
+			} else {
+				require.NoError(t, err)
+			}
 			if types.EnableGasVerification {
 				assert.Equal(t, tc.expectedGas, ctx.GasMeter().GasConsumed())
 			}

--- a/x/wasm/types/errors.go
+++ b/x/wasm/types/errors.go
@@ -84,6 +84,9 @@ var (
 
 	// ErrTopKevelKeyNotAllowed error if a JSON object has a top-level key that is not allowed
 	ErrTopKevelKeyNotAllowed = sdkErrors.Register(DefaultCodespace, 26, "top-level key is not allowed")
+
+	// ErrExceedMaxQueryStackSize error if max query stack size is exceeded
+	ErrExceedMaxQueryStackSize = sdkErrors.Register(DefaultCodespace, 27, "max query stack size exceeded")
 )
 
 type ErrNoSuchContract struct {

--- a/x/wasm/types/wasmer_engine.go
+++ b/x/wasm/types/wasmer_engine.go
@@ -5,6 +5,9 @@ import (
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 )
 
+// DefaultMaxQueryStackSize maximum size of the stack of contract instances doing queries
+const DefaultMaxQueryStackSize uint32 = 10
+
 // WasmerEngine defines the WASM contract runtime engine.
 type WasmerEngine interface {
 	// Create will compile the wasm code, and store the resulting pre-compile


### PR DESCRIPTION
Creates a query stack size limit

This PR is cherry picked from https://github.com/CosmWasm/wasmd/pull/867, which was patched in v0.27.0 upstream

This PR was patched being consensus breaking(https://github.com/CosmWasm/advisories/blob/main/CWAs/CWA-2022-004.md)