### PR TITLE
increase wasm size limit

### DIFF
--- a/x/wasm/types/validation.go
+++ b/x/wasm/types/validation.go
@@ -9,7 +9,7 @@ var (
 	MaxLabelSize = 128 // extension point for chains to customize via compile flag.
 
 	// MaxWasmSize is the largest a compiled contract code can be when storing code on chain
-	MaxWasmSize = 800 * 1024 // extension point for chains to customize via compile flag.
+	MaxWasmSize = 2600 * 1024 // extension point for chains to customize via compile flag.
 )
 
 func validateWasmCode(s []byte) error {


### PR DESCRIPTION
This increases the allowed WASM size from 800K to 2.6MB