### PR TITLE
Update Source to Code Source URL

### DIFF
--- a/docs/proto/proto-docs.md
+++ b/docs/proto/proto-docs.md
@@ -768,7 +768,7 @@ and instantiate the contract.
 | `label` | [string](#string) |  | Label is optional metadata to be stored with a constract instance. |
 | `msg` | [bytes](#bytes) |  | Msg json encoded message to be passed to the contract on instantiation |
 | `funds` | [cosmos.base.v1beta1.Coin](#cosmos.base.v1beta1.Coin) | repeated | Funds coins that are transferred to the contract on instantiation |
-| `source` | [string](#string) |  | Source is the URL where the code is hosted |
+| `code_source_url` | [string](#string) |  | CodeSourceURL is the URL where the code is hosted |
 | `builder` | [string](#string) |  | Builder is the docker image used to build the code deterministically, used for smart contract verification |
 | `code_hash` | [bytes](#bytes) |  | CodeHash is the SHA256 sum of the code outputted by builder, used for smart contract verification |
 
@@ -791,7 +791,7 @@ StoreCodeProposal gov proposal content type to submit WASM code to the system
 | `wasm_byte_code` | [bytes](#bytes) |  | WASMByteCode can be raw or gzip compressed |
 | `instantiate_permission` | [AccessConfig](#cosmwasm.wasm.v1.AccessConfig) |  | InstantiatePermission to apply on contract creation, optional |
 | `unpin_code` | [bool](#bool) |  | UnpinCode code on upload, optional |
-| `source` | [string](#string) |  | Source is the URL where the code is hosted |
+| `code_source_url` | [string](#string) |  | CodeSourceUrl is the URL where the code is hosted |
 | `builder` | [string](#string) |  | Builder is the docker image used to build the code deterministically, used for smart contract verification |
 | `code_hash` | [bytes](#bytes) |  | CodeHash is the SHA256 sum of the code outputted by builder, used for smart contract verification |
 

--- a/x/wasm/client/cli/gov_tx.go
+++ b/x/wasm/client/cli/gov_tx.go
@@ -114,7 +114,7 @@ func parseVerificationFlags(gzippedWasm []byte, flags *flag.FlagSet) (string, st
 	// if any set require others to be set
 	if len(source) != 0 || len(builder) != 0 || len(codeHash) != 0 {
 		if source == "" {
-			return "", "", nil, fmt.Errorf("source is required")
+			return "", "", nil, fmt.Errorf("code source url is required")
 		}
 		if _, err = url.ParseRequestURI(source); err != nil {
 			return "", "", nil, fmt.Errorf("source: %s", err)

--- a/x/wasm/client/cli/gov_tx.go
+++ b/x/wasm/client/cli/gov_tx.go
@@ -28,7 +28,7 @@ import (
 
 func ProposalStoreCodeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "wasm-store [wasm file] --title [text] --description [text] --run-as [address] --unpin-code [unpin_code] --source [source] --builder [builder] --code-hash [code_hash]",
+		Use:   "wasm-store [wasm file] --title [text] --description [text] --run-as [address] --unpin-code [unpin_code] --code-source-url [source] --builder [builder] --code-hash [code_hash]",
 		Short: "Submit a wasm binary proposal",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -271,7 +271,7 @@ func ProposalInstantiateContract2Cmd() *cobra.Command {
 func ProposalStoreAndInstantiateContractCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "store-instantiate [wasm file] [json_encoded_init_args] --label [text] --title [text] --description [text] --run-as [address]" +
-			"--unpin-code [unpin_code,optional] --source [source,optional] --builder [builder,optional] --code-hash [code_hash,optional] --admin [address,optional] --amount [coins,optional]",
+			"--unpin-code [unpin_code,optional] --code-source-url [source] --builder [builder,optional] --code-hash [code_hash,optional] --admin [address,optional] --amount [coins,optional]",
 		Short: "Submit and instantiate a wasm contract proposal",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/wasm/types/validation.go
+++ b/x/wasm/types/validation.go
@@ -59,7 +59,7 @@ func ValidateVerificationInfo(source, builder string, codeHash []byte) error {
 	// if any set require others to be set
 	if len(source) != 0 || len(builder) != 0 || codeHash != nil {
 		if source == "" {
-			return fmt.Errorf("source is required")
+			return fmt.Errorf("code source url is required")
 		}
 		if _, err := url.ParseRequestURI(source); err != nil {
 			return fmt.Errorf("source: %s", err)


### PR DESCRIPTION
When I was trying to create a governance proposal, I came to a block because `source` is required, but it's also not a recognized flag. As such, I made some updates to reflect that the user should set `code-source-url` rather than `source`.