### PR TITLE
fix: incorrect tracking of num instantiations

### DIFF
--- a/x/wasm/keeper/addresses.go
+++ b/x/wasm/keeper/addresses.go
@@ -22,11 +22,15 @@ func (k Keeper) ClassicAddressGenerator() AddressGenerator {
 }
 
 // PredicableAddressGenerator generates a predictable contract address
-func PredicableAddressGenerator(creator sdk.AccAddress, salt []byte, msg []byte, fixMsg bool) AddressGenerator {
+func (k Keeper) PredicableAddressGenerator(creator sdk.AccAddress, salt []byte, msg []byte, fixMsg bool) AddressGenerator {
 	return func(ctx sdk.Context, _ uint64, checksum []byte) sdk.AccAddress {
 		if !fixMsg { // clear msg to not be included in the address generation
 			msg = []byte{}
 		}
+		// increment the instanceID counter despite it being unused.
+		// we use this as state verification to ensure we have the same
+		// number of instantiated contracts after exporting and importing genesis.
+		k.autoIncrementID(ctx, types.KeyLastInstanceID)
 		return BuildContractAddressPredictable(checksum, creator, salt, msg)
 	}
 }

--- a/x/wasm/keeper/contract_keeper.go
+++ b/x/wasm/keeper/contract_keeper.go
@@ -32,6 +32,7 @@ type decoratedKeeper interface {
 	setContractInfoExtension(ctx sdk.Context, contract sdk.AccAddress, extra types.ContractInfoExtension) error
 	setAccessConfig(ctx sdk.Context, codeID uint64, caller sdk.AccAddress, newConfig types.AccessConfig, autz AuthorizationPolicy) error
 	ClassicAddressGenerator() AddressGenerator
+	PredicableAddressGenerator(creator sdk.AccAddress, salt []byte, msg []byte, fixMsg bool) AddressGenerator
 }
 
 type PermissionedKeeper struct {
@@ -86,7 +87,7 @@ func (p PermissionedKeeper) Instantiate2(
 		initMsg,
 		label,
 		deposit,
-		PredicableAddressGenerator(creator, salt, initMsg, fixMsg),
+		p.nested.PredicableAddressGenerator(creator, salt, initMsg, fixMsg),
 		p.authZPolicy,
 	)
 }

--- a/x/wasm/keeper/genesis.go
+++ b/x/wasm/keeper/genesis.go
@@ -123,8 +123,7 @@ func ExportGenesis(ctx sdk.Context, keeper *Keeper) *types.GenesisState {
 	})
 	genState.Sequences = append(genState.Sequences, types.Sequence{
 		IDKey: types.KeyLastInstanceID,
-		// We subtract by 1 here, because there is such thing as contract number 0 (why?!)
-		Value: totalNumContracts - 1,
+		Value: totalNumContracts + 1,
 	})
 	// TODO END: Once a chain correct the last instance ID, the can remove this
 

--- a/x/wasm/keeper/genesis.go
+++ b/x/wasm/keeper/genesis.go
@@ -35,7 +35,7 @@ func InitGenesis(ctx sdk.Context, keeper *Keeper, data types.GenesisState) ([]ab
 		}
 	}
 
-	// var maxContractID int
+	var maxContractID int
 	for i, contract := range data.Contracts {
 		contractAddr, err := sdk.AccAddressFromBech32(contract.ContractAddress)
 		if err != nil {
@@ -45,7 +45,7 @@ func InitGenesis(ctx sdk.Context, keeper *Keeper, data types.GenesisState) ([]ab
 		if err != nil {
 			return nil, sdkerrors.Wrapf(err, "contract number %d", i)
 		}
-		// maxContractID = i + 1 // not ideal but max(contractID) is not persisted otherwise
+		maxContractID = i + 1 // not ideal but max(contractID) is not persisted otherwise
 	}
 
 	for i, seq := range data.Sequences {
@@ -60,12 +60,10 @@ func InitGenesis(ctx sdk.Context, keeper *Keeper, data types.GenesisState) ([]ab
 	if seqVal <= maxCodeID {
 		return nil, sdkerrors.Wrapf(types.ErrInvalid, "seq %s with value: %d must be greater than: %d ", string(types.KeyLastCodeID), seqVal, maxCodeID)
 	}
-	// TODO START: Once a chain corrects the last instance ID, they can uncomment this
-	// seqVal = keeper.PeekAutoIncrementID(ctx, types.KeyLastInstanceID)
-	// if seqVal <= uint64(maxContractID) {
-	// 	return nil, sdkerrors.Wrapf(types.ErrInvalid, "seq %s with value: %d must be greater than: %d ", string(types.KeyLastInstanceID), seqVal, maxContractID)
-	// }
-	// TODO END: Once a chain corrects the last instance ID, they can uncomment this
+	seqVal = keeper.PeekAutoIncrementID(ctx, types.KeyLastInstanceID)
+	if seqVal <= uint64(maxContractID) {
+		return nil, sdkerrors.Wrapf(types.ErrInvalid, "seq %s with value: %d must be greater than: %d ", string(types.KeyLastInstanceID), seqVal, maxContractID)
+	}
 	return nil, nil
 }
 

--- a/x/wasm/keeper/genesis.go
+++ b/x/wasm/keeper/genesis.go
@@ -123,7 +123,8 @@ func ExportGenesis(ctx sdk.Context, keeper *Keeper) *types.GenesisState {
 	})
 	genState.Sequences = append(genState.Sequences, types.Sequence{
 		IDKey: types.KeyLastInstanceID,
-		Value: totalNumContracts,
+		// We subtract by 1 here, because there is such thing as contract number 0 (why?!)
+		Value: totalNumContracts - 1,
 	})
 	// TODO END: Once a chain correct the last instance ID, the can remove this
 


### PR DESCRIPTION
Every time we instantiate a contract the classic way, we increment types.KeySequenceInstanceID: https://github.com/CosmWasm/wasmd/blob/e0bfaa52317a3d1f73bf26c5b9d61a777f63bd88/x/wasm/keeper/addresses.go#L17-L22
Every time we instantiate a contract with a predictable address (instantiate2), we do not increment this ID: https://github.com/CosmWasm/wasmd/blob/e0bfaa52317a3d1f73bf26c5b9d61a777f63bd88/x/wasm/keeper/addresses.go#L24-L32
In ImportGenesis, maxContractID takes into consideration ALL contracts: https://github.com/CosmWasm/wasmd/blob/e0bfaa52317a3d1f73bf26c5b9d61a777f63bd88/x/wasm/keeper/genesis.go#L45-L55
ImportGenesis expects the types.KeySequenceInstanceID to be greater than the number of contracts, but its not since we don’t always increment this value: https://github.com/CosmWasm/wasmd/blob/e0bfaa52317a3d1f73bf26c5b9d61a777f63bd88/x/wasm/keeper/genesis.go#L69-L72

This means that the discrepancy between the expected value and the actual value should be all contracts that were instantiated with predictable addresses.

This fix manually increments the KeyLastInstanceID to what we expect it to be. This way the check in InitGenesis passes. This also increments the KeyLastInstanceID on all instantiate2 calls. If chains manually set this key to the correct value in their upgrade handler, they can remove the manual setting of the KeyLastInstanceID in export genesis (but it's probably not a big deal if this isn't touched).